### PR TITLE
Fix the spell slots of the character sheet not updating after smite

### DIFF
--- a/actor/divine_smite.js
+++ b/actor/divine_smite.js
@@ -96,5 +96,7 @@ function smite(slotLevel) {
         new Roll(`${numDice}d8`).roll().toMessage({ flavor: "Macro Divine Smite - Damage Roll (Radiant)", speaker })
     })
 
-    chosenSpellSlots.value -= 1;
+    let objUpdate = new Object();
+    objUpdate['data.spells.spell' + slotLevel + '.value'] = chosenSpellSlots.value - 1;
+    controlledActor.update(objUpdate);
 }


### PR DESCRIPTION
- Fix smite not updating the spell slots in the character sheet if it is open
- Close #100